### PR TITLE
enkimi is now able to be used as a subdirectory in a cmake project, example now copies dependencies into binary directory 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,9 @@ cmake_minimum_required(VERSION 2.8)
 
 project( enkiMI )
 
-include_directories ("${PROJECT_SOURCE_DIR}/src")
-
-set( ENKIMI_SRC
-     example/example.c
-     src/miniz.h
-	 src/miniz.c
-	 src/enkimi.h
-	 src/enkimi.c
-	 )
-	 
-add_executable( example ${ENKIMI_SRC} )
+#now our enkiMI target is available to everything below
+add_subdirectory(src)
+option(ENKIMI_ENABLE_EXAMPLE "Enable the enkiMI project example executable target" OFF)
+if(ENKIMI_ENABLE_EXAMPLE)
+	add_subdirectory(example)
+endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 2.8)
+
+project( enkiMI )
+
+add_executable(enkimi_example)
+target_sources(enkimi_example
+        PRIVATE
+        example.c)
+target_link_libraries(enkimi_example
+        PRIVATE
+        enkiMI::enkimi)
+#copy our example minecraft chunk file so our example runs regardless of directory the source exists in.
+add_custom_command(
+        TARGET enkimi_example POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_CURRENT_SOURCE_DIR}/r.1.0.mca
+                ${CMAKE_CURRENT_BINARY_DIR}/r.1.0.mca
+        )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8)
+
+project( enkiMI )
+#for backward compatsake, using capital enkiMI, convention though is usually lowercase
+add_library(enkiMI)
+target_sources(enkiMI PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/miniz.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/miniz.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/enkimi.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/enkimi.c
+        )
+#if we don't use current source directory, we can't use this project as a submodule
+target_include_directories(enkiMI PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/)
+
+
+add_library(enkiMI::enkimi ALIAS enkiMI)


### PR DESCRIPTION
enkiMI target is now able to be used independently of the executable target, how also has an alias target, can be used as a subdirectory, added ability to conditionally include build files for executable example, example target now exists as enkimi_example, and now copies its .mca runtime dependency as part of the build process using CMake, allowing it to execute with out user taking into consideration where the source is.

With out these changes, using this project as a library would not have been able to be used as a subdirectory in cmake, and building the example would not have been possible with out the copying of its runtime dependencies.